### PR TITLE
Support for configurable parameters for inverter command response buffers

### DIFF
--- a/config/inverter.conf
+++ b/config/inverter.conf
@@ -18,10 +18,25 @@ run_interval=120
 # reading compared to measurement tools.  Normally this will remain '1'
 amperage_factor=1.0
 
-# This allos you to modify the wattage in case the inverter is giving an incorrect
+# This allows you to modify the wattage in case the inverter is giving an incorrect
 # reading compared to measurement tools.  Normally this will remain '1'
 watt_factor=1.01
 
+
+# The following settings allow you to modify runtime buffers.
+# N.B. These values may not be applicable to all inverter types, as such you will 
+# need to run docker exec -it voltronic-mqtt bash -c '/opt/inverter-cli/bin/inverter_poller -d -1'
+# or simply inverter_poller -d -1 to check for warnings or errors
+# mentioned in https://github.com/ned-kelly/docker-voltronic-homeassistant/issues/5
+
 # This allows you to modify the buffersize for the qpiri command
-# as mentioned in https://github.com/ned-kelly/docker-voltronic-homeassistant/issues/5
 qpiri=97
+
+# This allows you to modify the buffersize for the qpiws command
+qpiws=36
+
+# This allows you to modify the buffersize for the qmod command
+qmod=5
+
+# This allows you to modify the buffersize for the qpigs command
+qpigs=110

--- a/sources/inverter-cli/inverter.cpp
+++ b/sources/inverter-cli/inverter.cpp
@@ -9,13 +9,16 @@
 #include <fcntl.h>
 #include <termios.h>
 
-cInverter::cInverter(std::string devicename, int qpiri) {
+cInverter::cInverter(std::string devicename, int qpiri, int qpiws, int qmod, int qpigs) {
     device = devicename;
     status1[0] = 0;
     status2[0] = 0;
     warnings[0] = 0;
     mode = 0;
     qpiri = qpiri;
+    qpiws = qpiws;
+    qmod = qmod;
+    qpigs = qpigs;
 }
 
 string *cInverter::GetQpigsStatus() {
@@ -154,13 +157,13 @@ bool cInverter::query(const char *cmd, int replysize) {
 
 void cInverter::poll() {
     int n,j;
-    extern const int qpiri;
+    extern const int qpiri, qpiws, qmod, qpigs;
 
     while (true) {
 
         // Reading mode
         if (!ups_qmod_changed) {
-            if (query("QMOD", 5)) {
+            if (query("QMOD", qmod)) {
                 SetMode(buf[1]);
                 ups_qmod_changed = true;
             }
@@ -168,7 +171,7 @@ void cInverter::poll() {
 
         // reading status (QPIGS)
         if (!ups_qpigs_changed) {
-            if (query("QPIGS", 110)) {
+            if (query("QPIGS", qpigs)) {
                 m.lock();
                 strcpy(status1, (const char*)buf+1);
                 m.unlock();
@@ -188,7 +191,7 @@ void cInverter::poll() {
 
         // Get any device warnings...
         if (!ups_qpiws_changed) {
-            if (query("QPIWS", 36)) {
+            if (query("QPIWS", qpiws)) {
                 m.lock();
                 strcpy(warnings, (const char*)buf+1);
                 m.unlock();

--- a/sources/inverter-cli/inverter.h
+++ b/sources/inverter-cli/inverter.h
@@ -23,7 +23,7 @@ class cInverter {
     uint16_t cal_crc_half(uint8_t *pin, uint8_t len);
 
     public:
-        cInverter(std::string devicename, int qpiri);
+        cInverter(std::string devicename, int qpiri, int qpiws, int qmod, int qpigs);
         void poll();
         void runMultiThread() {
             std::thread t1(&cInverter::poll, this);

--- a/sources/inverter-cli/main.cpp
+++ b/sources/inverter-cli/main.cpp
@@ -43,7 +43,7 @@ string devicename;
 int runinterval;
 float ampfactor;
 float wattfactor;
-int qpiri;
+int qpiri, qpiws, qmod, qpigs;
 
 // ---------------------------------------
 
@@ -93,6 +93,12 @@ void getSettingsFile(string filename) {
                     attemptAddSetting(&wattfactor, linepart2);
                 else if(linepart1 == "qpiri")
                     attemptAddSetting(&qpiri, linepart2);
+                else if(linepart1 == "qpiws")
+                    attemptAddSetting(&qpiws, linepart2);
+                else if(linepart1 == "qmod")
+                    attemptAddSetting(&qmod, linepart2);
+                else if(linepart1 == "qpigs")
+                    attemptAddSetting(&qpigs, linepart2);
                 else
                     continue;
             }
@@ -174,7 +180,7 @@ int main(int argc, char* argv[]) {
     }
 
     bool ups_status_changed(false);
-    ups = new cInverter(devicename,qpiri);
+    ups = new cInverter(devicename,qpiri,qpiws,qmod,qpigs);
 
     // Logic to send 'raw commands' to the inverter..
     if (!rawcmd.empty()) {


### PR DESCRIPTION
## Description
**Satisfied partial requirement for issue: #5** 
Allow users to configure additional parameters in the `inverter.conf` for the following commands:
- *QPIWS*
- *QMOD*
- *QPIGS*

This should allow easier matching of response sizes for any given inverter type.

## How Has This Been Tested?
1. Made sure that the project builds
2. Ran compiled program on a raspberry pi

## Types of changes
- [X] New feature (non-breaking change which adds functionality)