### PR TITLE
inverter-mqtt/mqtt-push.sh: optimize

### DIFF
--- a/sources/inverter-mqtt/mqtt-push.sh
+++ b/sources/inverter-mqtt/mqtt-push.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 INFLUX_ENABLED=`cat /etc/inverter/mqtt.json | jq '.influx.enabled' -r`
 
+MQTT_SERVER=`cat /etc/inverter/mqtt.json | jq '.server' -r`
+MQTT_PORT=`cat /etc/inverter/mqtt.json | jq '.port' -r`
+MQTT_TOPIC=`cat /etc/inverter/mqtt.json | jq '.topic' -r`
+MQTT_DEVICENAME=`cat /etc/inverter/mqtt.json | jq '.devicename' -r`
+MQTT_USERNAME=`cat /etc/inverter/mqtt.json | jq '.username' -r`
+MQTT_PASSWORD=`cat /etc/inverter/mqtt.json | jq '.password' -r`
+MQTT_CLIENTID=`cat /etc/inverter/mqtt.json | jq '.clientid' -r`
+
 pushMQTTData () {
-    MQTT_SERVER=`cat /etc/inverter/mqtt.json | jq '.server' -r`
-    MQTT_PORT=`cat /etc/inverter/mqtt.json | jq '.port' -r`
-    MQTT_TOPIC=`cat /etc/inverter/mqtt.json | jq '.topic' -r`
-    MQTT_DEVICENAME=`cat /etc/inverter/mqtt.json | jq '.devicename' -r`
-    MQTT_USERNAME=`cat /etc/inverter/mqtt.json | jq '.username' -r`
-    MQTT_PASSWORD=`cat /etc/inverter/mqtt.json | jq '.password' -r`
-	MQTT_CLIENTID=`cat /etc/inverter/mqtt.json | jq '.clientid' -r`
 
     mosquitto_pub \
         -h $MQTT_SERVER \


### PR DESCRIPTION
On Raspberry Pi 3B executing the original code, with Influx disabled, takes:
```
real    0m57,753s
user    0m54,679s
sys     0m2,214s
```
With the modification the time is:
```
real    0m10,733s
user    0m8,338s
sys     0m0,759s
```
For the record, I run the code outside of containers.