### PR TITLE
inverter-cli/main.cpp: remove tautology

### DIFF
--- a/sources/inverter-cli/main.cpp
+++ b/sources/inverter-cli/main.cpp
@@ -89,8 +89,6 @@ void getSettingsFile(string filename) {
                     attemptAddSetting(&ampfactor, linepart2);
                 else if(linepart1 == "watt_factor")
                     attemptAddSetting(&wattfactor, linepart2);
-                else if(linepart1 == "watt_factor")
-                    attemptAddSetting(&wattfactor, linepart2);
                 else if(linepart1 == "qpiri")
                     attemptAddSetting(&qpiri, linepart2);
                 else if(linepart1 == "qpiws")


### PR DESCRIPTION
Closes: https://github.com/ned-kelly/docker-voltronic-homeassistant/issues/68
Related-To: https://github.com/manio/skymax-demo/issues/10